### PR TITLE
Migrate to ViewBinding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
-    id 'kotlin-android-extensions'
+    id 'kotlin-parcelize'
 }
 
 android {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,6 +7,10 @@ plugins {
 android {
     compileSdkVersion 30
 
+    buildFeatures {
+        viewBinding = true
+    }
+
     defaultConfig {
         applicationId "dev.msfjarvis.mobiusdemo"
         minSdkVersion 23

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.lifecycle:lifecycle-common-java8:2.2.0'
     implementation 'com.google.android.material:material:1.2.1'
     implementation "com.spotify.mobius:mobius-core:$mobius_version"
     implementation "com.spotify.mobius:mobius-android:$mobius_version"

--- a/app/src/main/java/dev/msfjarvis/counter/CounterActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/counter/CounterActivity.kt
@@ -7,7 +7,7 @@ import com.spotify.mobius.Connection
 import com.spotify.mobius.Mobius
 import com.spotify.mobius.android.MobiusAndroid
 import dev.msfjarvis.mobiusdemo.R
-import kotlinx.android.synthetic.main.counter_activity.*
+import dev.msfjarvis.mobiusdemo.databinding.CounterActivityBinding
 
 class CounterActivity : AppCompatActivity(R.layout.counter_activity) {
     private val loopFactory = Mobius.loop(CounterUpdate(), {
@@ -21,6 +21,7 @@ class CounterActivity : AppCompatActivity(R.layout.counter_activity) {
     })
 
     private val controller = MobiusAndroid.controller(loopFactory, CounterModel.default())
+    private val binding by viewBinding(CounterActivityBinding::inflate)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -30,25 +31,25 @@ class CounterActivity : AppCompatActivity(R.layout.counter_activity) {
         controller.connect { eventConsumer ->
             object : Connection<CounterModel> {
                 override fun dispose() {
-                    increment_button.setOnClickListener(null)
-                    decrement_button.setOnClickListener(null)
+                    binding.incrementButton.setOnClickListener(null)
+                    binding.decrementButton.setOnClickListener(null)
                 }
 
                 override fun accept(value: CounterModel) {
-                    counter_textview.text = "${value.value}"
+                    binding.counterTextview.text = "${value.value}"
 
                     if (value.error != null) {
-                        error_textview.isVisible = true
-                        error_textview.text = "Cannot decrement below zero"
+                        binding.errorTextview.isVisible = true
+                        binding.errorTextview.text = "Cannot decrement below zero"
                     } else {
-                        error_textview.isVisible = false
+                        binding.errorTextview.isVisible = false
                     }
 
-                    increment_button.setOnClickListener {
+                    binding.incrementButton.setOnClickListener {
                         eventConsumer.accept(CounterEvent.Increment)
                     }
 
-                    decrement_button.setOnClickListener {
+                    binding.decrementButton.setOnClickListener {
                         eventConsumer.accept(CounterEvent.Decrement)
                     }
                 }

--- a/app/src/main/java/dev/msfjarvis/counter/CounterError.kt
+++ b/app/src/main/java/dev/msfjarvis/counter/CounterError.kt
@@ -1,7 +1,7 @@
 package dev.msfjarvis.counter
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 sealed class CounterError : Parcelable {
     @Parcelize

--- a/app/src/main/java/dev/msfjarvis/counter/CounterModel.kt
+++ b/app/src/main/java/dev/msfjarvis/counter/CounterModel.kt
@@ -1,7 +1,7 @@
 package dev.msfjarvis.counter
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class CounterModel(val value: Int, val error: CounterError?): Parcelable {

--- a/app/src/main/java/dev/msfjarvis/counter/FragmentViewBindingDelegate.kt
+++ b/app/src/main/java/dev/msfjarvis/counter/FragmentViewBindingDelegate.kt
@@ -1,0 +1,59 @@
+package dev.msfjarvis.counter
+
+import android.view.LayoutInflater
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.viewbinding.ViewBinding
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Imported from https://medium.com/@Zhuinden/simple-one-liner-viewbinding-in-fragments-and-activities-with-kotlin-961430c6c07c
+ */
+class FragmentViewBindingDelegate<T : ViewBinding>(
+    val fragment: Fragment,
+    val viewBindingFactory: (View) -> T
+) : ReadOnlyProperty<Fragment, T> {
+
+    private var binding: T? = null
+
+    init {
+        fragment.lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onCreate(owner: LifecycleOwner) {
+                fragment.viewLifecycleOwnerLiveData.observe(fragment) { viewLifecycleOwner ->
+                    viewLifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
+                        override fun onDestroy(owner: LifecycleOwner) {
+                            binding = null
+                        }
+                    })
+                }
+            }
+        })
+    }
+
+    override fun getValue(thisRef: Fragment, property: KProperty<*>): T {
+        val binding = binding
+        if (binding != null) {
+            return binding
+        }
+
+        val lifecycle = fragment.viewLifecycleOwner.lifecycle
+        if (!lifecycle.currentState.isAtLeast(Lifecycle.State.INITIALIZED)) {
+            throw IllegalStateException("Should not attempt to get bindings when Fragment views are destroyed.")
+        }
+
+        return viewBindingFactory(thisRef.requireView()).also { this.binding = it }
+    }
+}
+
+fun <T : ViewBinding> Fragment.viewBinding(viewBindingFactory: (View) -> T) =
+    FragmentViewBindingDelegate(this, viewBindingFactory)
+
+inline fun <T : ViewBinding> AppCompatActivity.viewBinding(crossinline bindingInflater: (LayoutInflater) -> T) =
+    lazy(LazyThreadSafetyMode.NONE) {
+        bindingInflater.invoke(layoutInflater)
+    }


### PR DESCRIPTION
- build(app): enable ViewBinding build feature
- FragmentViewBindingDelegate: helper for auto-clearing ViewBinding references
- CounterActivity: migrate to ViewBinding
- build(app): replace kotlin-android-extensions with kotlin-parcelize
